### PR TITLE
Logmaker/FunctionTracer: add the initial version of FunctionTracer

### DIFF
--- a/LogMaker/FunctionTracer/Makefile
+++ b/LogMaker/FunctionTracer/Makefile
@@ -1,0 +1,19 @@
+PIN_ROOT = ../pin/
+ifneq ("$(PIN_ROOT)", "")
+	CONFIG_ROOT := $(PIN_ROOT)/source/tools/Config
+	include $(CONFIG_ROOT)/makefile.config
+	include $(TOOLS_ROOT)/Config/makefile.default.rules
+endif
+
+all: intel64
+
+intel64:
+ifeq ("$(PIN_ROOT)", "")
+ # PIN_ROOT has to point the root directory of pin-3.0-76991-gcc-linux
+	$(error PIN_ROOT variable is not set)
+endif
+	$(MAKE) TARGET=intel64 obj-intel64/call_cust.so
+	mv obj-intel64/call_cust.so .
+
+clean:
+	rm -rf obj-intel64 call_cust.so

--- a/LogMaker/FunctionTracer/call_cust.cpp
+++ b/LogMaker/FunctionTracer/call_cust.cpp
@@ -1,0 +1,248 @@
+
+#include "pin.H"
+#include <iostream>
+#include <fstream>
+
+
+/* ===================================================================== */
+/* Global Variables */
+/* ===================================================================== */
+
+std::ofstream TraceFile;
+std::vector<string> calls_list;
+std::map<std::string, int> countMap;
+
+/* ===================================================================== */
+/* Commandline Switches */
+/* ===================================================================== */
+
+KNOB<string> KnobOutputFile(KNOB_MODE_WRITEONCE, "pintool", "o", "calltrace.out", "specify trace file name");
+KNOB<BOOL>   KnobPrintArgs(KNOB_MODE_WRITEONCE, "pintool", "a", "0", "print call arguments ");
+KNOB<BOOL>   KnobAllCalls(KNOB_MODE_WRITEONCE, "pintool", "c", "0", "print all calls ");
+
+
+/* ===================================================================== */
+/* Print Help Message                                                    */
+/* ===================================================================== */
+
+INT32 Usage()
+{
+    cerr << "This tool produces a call trace." << endl << endl;
+    cerr << KNOB_BASE::StringKnobSummary() << endl;
+    return -1;
+}
+
+string invalid = "$";
+
+/* ===================================================================== */
+const string *Target2String(ADDRINT target)
+{
+    string name = RTN_FindNameByAddress(target);
+    if (name == "")
+        return &invalid;
+    else
+        return new string(name);
+}
+
+/* ===================================================================== */
+
+VOID  do_call_args(const string *s, ADDRINT arg0)
+{
+    TraceFile << *s << "(" << arg0 << ",...)" << endl;
+}
+
+/* ===================================================================== */
+
+VOID  do_call_args_indirect(ADDRINT target, BOOL taken, ADDRINT arg0)
+{
+    if( !taken ) return;
+    
+    const string *s = Target2String(target);
+    do_call_args(s, arg0);
+
+    if (s != &invalid)
+        delete s;
+}
+
+/* ===================================================================== */
+
+VOID  do_call(const string *s)
+{
+    // Here we check for _Exit because that's the last call happening before the binary teminates.
+    if(*s != "_Exit")
+        calls_list.push_back(*s);
+    else if(*s == "_Exit"){ 
+        for(unsigned int i = 0; i < calls_list.size();i++)
+        {
+            string ser = calls_list[i];
+            //Switch cases for parsing the list we have 
+            switch (ser[0])
+            {
+            case '.':
+                break;
+            case '_':
+                break;
+            case '$':
+                break;
+            case '(':
+                break;
+            case '#':
+                break;
+            case '@':
+                break;
+            default:
+                //cout << ser[0] << endl;
+                //TraceFile << ser << endl;
+                auto result = countMap.insert(std::pair<std::string, int>(ser, 1));
+	            if (result.second == false)
+		            result.first->second++;
+                break;
+            }
+        }
+        if ( std::find(calls_list.begin(), calls_list.end(), "ptrace@plt") != calls_list.end() ) 
+        {
+            cout << "================Analysis Complete================"<<endl;
+            cout << "PTRACE detected" <<endl;
+            cout << "======================Stats ====================="<<endl;
+        }
+        for (auto & elem : countMap){
+	    // If frequency count is greater than 1 then its a duplicate element
+	        if (elem.second >= 1){
+		        std::cout << elem.first << " was called " << elem.second << " times."<< std::endl;
+	        }
+        }
+    }
+}
+
+
+/* ===================================================================== */
+
+VOID  do_call_indirect(ADDRINT target, BOOL taken)
+{
+    if( !taken ) return;
+
+    const string *s = Target2String(target);
+    do_call( s );
+    
+    if (s != &invalid)
+        delete s;
+}
+
+/* ===================================================================== */
+
+VOID Trace(TRACE trace, VOID *v)
+{
+    const BOOL print_args = KnobPrintArgs.Value();
+    
+        
+    for (BBL bbl = TRACE_BblHead(trace); BBL_Valid(bbl); bbl = BBL_Next(bbl))
+    {
+        INS tail = BBL_InsTail(bbl);
+        
+        if( INS_IsCall(tail) )
+        {
+            if( INS_IsDirectBranchOrCall(tail) )
+            {
+                const ADDRINT target = INS_DirectBranchOrCallTargetAddress(tail);
+                if( print_args )
+                {
+                    INS_InsertPredicatedCall(tail, IPOINT_BEFORE, AFUNPTR(do_call_args),
+                                             IARG_PTR, Target2String(target), IARG_FUNCARG_CALLSITE_VALUE, 0, IARG_END);
+                }
+                else
+                {
+                    INS_InsertPredicatedCall(tail, IPOINT_BEFORE, AFUNPTR(do_call),
+                                             IARG_PTR, Target2String(target), IARG_END);
+                }
+                
+            }
+            else
+            {
+                if( print_args )
+                {
+                    INS_InsertCall(tail, IPOINT_BEFORE, AFUNPTR(do_call_args_indirect),
+                                   IARG_BRANCH_TARGET_ADDR, IARG_BRANCH_TAKEN,  IARG_FUNCARG_CALLSITE_VALUE, 0, IARG_END);
+                }
+                else
+                {
+                    INS_InsertCall(tail, IPOINT_BEFORE, AFUNPTR(do_call_indirect),
+                                   IARG_BRANCH_TARGET_ADDR, IARG_BRANCH_TAKEN, IARG_END);
+                }
+                
+                
+            }
+        }
+        else
+        {
+            // sometimes code is not in an image
+            RTN rtn = TRACE_Rtn(trace);
+            
+            // also track stup jumps into share libraries
+            if( RTN_Valid(rtn) && !INS_IsDirectBranchOrCall(tail) && ".plt" == SEC_Name( RTN_Sec( rtn ) ))
+            {
+                if( print_args )
+                {
+                    INS_InsertCall(tail, IPOINT_BEFORE, AFUNPTR(do_call_args_indirect),
+                                   IARG_BRANCH_TARGET_ADDR, IARG_BRANCH_TAKEN,  IARG_FUNCARG_CALLSITE_VALUE, 0, IARG_END);
+                }
+                else
+                {
+                    INS_InsertCall(tail, IPOINT_BEFORE, AFUNPTR(do_call_indirect),
+                                   IARG_BRANCH_TARGET_ADDR, IARG_BRANCH_TAKEN, IARG_END);
+
+                }
+            }
+        }
+        
+    }
+}
+
+/* ===================================================================== */
+
+VOID Fini(INT32 code, VOID *v)
+{
+    TraceFile << "# eof" << endl;
+    
+    TraceFile.close();
+}
+
+/* ===================================================================== */
+/* Main                                                                  */
+/* ===================================================================== */
+
+int  main(int argc, char *argv[])
+{
+    
+    PIN_InitSymbols();
+
+    if( PIN_Init(argc,argv) )
+    {
+        return Usage();
+    }
+    
+
+    TraceFile.open(KnobOutputFile.Value().c_str());
+
+    TraceFile << hex;
+    TraceFile.setf(ios::showbase);
+    
+    string trace_header = string("#\n"
+                                 "# Call Trace Generated By Pin\n"
+                                 "#\n");
+    
+
+    TraceFile.write(trace_header.c_str(),trace_header.size());
+    
+    TRACE_AddInstrumentFunction(Trace, 0);
+    PIN_AddFiniFunction(Fini, 0);
+
+    // Never returns
+
+    PIN_StartProgram();
+    
+    return 0;
+}
+
+/* ===================================================================== */
+/* eof */
+/* ===================================================================== */

--- a/test/ptrace.c
+++ b/test/ptrace.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <sys/ptrace.h>
+
+int main()
+{
+	if (ptrace(PTRACE_TRACEME, 0, 1, 0) == -1) 
+		{
+			printf("don't trace me !!\n");
+			return 1;
+		}
+	// normal execution
+	printf("The normal path\n");
+	return 0;
+}


### PR DESCRIPTION
**Logmaker/FunctionTracer: add the initial version of FunctionTracer**

In this I've added the initial version of FunctionTracer.
The Current version checks out the following features from issue #9.

- [X]  Iterate through the entire program and get details on all the function calls

- [X] Sort whether each call is a library call or a user defined call
- As of now it only prints out a few functions that I've hand picked

- [X] Store statistics of each function call (ie how many times is it called)

- There is a small issue with the numbering. I'm currently looking into why it's wrong in a few cases For ex: Ptrace

- [X] Sort function calls - by callee functions

- The functions are printed in the same order as they are called.  

A gist containing the output of Pintool is as follows - [Link](https://gist.github.com/Freakston/7bc503c7873a1320eccab7bc4ee678d1)