### PR TITLE
added function call stack

### DIFF
--- a/TaintTracker/TaintTracker.cpp
+++ b/TaintTracker/TaintTracker.cpp
@@ -5,6 +5,7 @@
 #include <list>
 
 #include "TaintTracker.h"
+TaintTracker taintEngine(256);
 
 /*
  * BASIC UTILITY FUNCTIONS

--- a/TaintTracker/TaintTracker.cpp
+++ b/TaintTracker/TaintTracker.cpp
@@ -1,15 +1,11 @@
 #include "pin.H"
-#include <asm/unistd.h>
-#include <fstream>
-#include <iostream>
-#include <list>
-
 #include "TaintTracker.h"
 TaintTracker taintEngine(256);
 
 /*
  * BASIC UTILITY FUNCTIONS
  */
+#define LIBC_BASE 0x700000000000
 
 int usage()
 {
@@ -17,9 +13,28 @@ int usage()
     return -1;
 }
 
-bool isLibraryFunction() {
-    // TODO : Figure out to do this
-    return true;
+bool isLibraryFunction(UINT64 addr) {
+    // TODO : Temporary hack
+    // Figure out to do this
+    if (addr > LIBC_BASE) {
+        return true;
+    }
+    return false;
+}
+
+//TODO: get names of functions if available
+void showstack(stack <UINT64> s)
+{
+    std::cout << "[Function Backtrace]" << endl;
+    std::cout << "--------------------";
+    while (!s.empty())
+    {
+        std::cout << "\nsub_" << s.top();
+        s.pop();
+    }
+    std::cout << '\n';
+    std::cout << "--------------------" << endl;
+    std::cout << "[  END  BACKTRACE  ]" << endl;
 }
 /*
  * END OF BASIC UTILITY FUNCTIONS
@@ -65,11 +80,31 @@ bool TaintTracker::checkTaint(UINT64 addr) {
 /*
  * TAINT TRACKER DEBUG FUNCTIONS
  */
+// TODO: Code for reference, clean up later
+// void TaintTracker::callFunctionReg(UINT64 insAddr, std::string insDis, REG reg, CONTEXT * ctx)
+// {
+//     std::cout << "[CALL] at 0x" << insAddr << "] " << insDis << " calls 0x" << static_cast<UINT64>((PIN_GetContextReg(ctx, REG_FullRegName(reg))))<< std::endl;
+// }
+
+void TaintTracker::callFunction(UINT64 insAddr, std::string insDis, UINT64 addr)
+{
+    //std::cout << "[CALL] at 0x" << insAddr << "] " << insDis << " calls 0x" << addr << std::endl;
+    taintEngine.callStack.push(addr);
+}
+
+void TaintTracker::retFunction(UINT64 insAddr, std::string insDis)
+{
+    //UINT64 addr = taintEngine.callStack.top();
+    //std::cout << "[RETURN] " << insDis << "popped 0x" << addr << endl;
+    taintEngine.callStack.pop();
+}
+
 void TaintTracker::readMem(UINT64 insAddr, std::string insDis, UINT64 memOp)
 {
     if (taintEngine.checkTaint(memOp)) {
         std::cout << std::hex << "[READ in 0x" << memOp << "]\t"
                   << insAddr << ": " << insDis<< std::endl;
+        showstack(taintEngine.callStack);
     }
 }
 
@@ -78,6 +113,7 @@ void TaintTracker::writeMem(UINT64 insAddr, std::string insDis, UINT64 memOp)
     if (taintEngine.checkTaint(memOp)) {
         std::cout << std::hex << "[WRITE in 0x" << memOp << "]\t"
                   << insAddr << ": " << insDis << std::endl;
+        showstack(taintEngine.callStack);
     }
 }
 
@@ -115,8 +151,46 @@ void Trace(TRACE trace, VOID *v) {
                 }
             }
             */
+
+            // XXX Gives cleaner output, but implementation is incorrect
+            if (isLibraryFunction(INS_Address(ins))) {
+                continue;
+            }
+
+            if (INS_Disassemble(ins).rfind("call") == 0) {
+                // TODO: Code for reference, clean up later
+                // if (INS_OperandIsReg(ins, 0)) {
+                // INS_InsertCall(
+                //                ins, IPOINT_BEFORE,(AFUNPTR)taintEngine.callFunctionReg,
+                //                IARG_ADDRINT, INS_Address(ins),
+                //                IARG_PTR, new string(INS_Disassemble(ins)),
+                //                IARG_UINT64, INS_OperandReg(ins, 0),
+                //                IARG_CONTEXT, IARG_END);
+                // } else if (INS_OperandIsMemory(ins, 0)) {
+                // INS_InsertCall(
+                //                ins, IPOINT_BEFORE,(AFUNPTR)taintEngine.callFunctionImm,
+                //                IARG_ADDRINT, INS_Address(ins),
+                //                IARG_PTR, new string(INS_Disassemble(ins)),
+                //                IARG_MEMORYOP_EA, 0,
+                //                IARG_END);
+                // } else {
+                INS_InsertCall(
+                               ins, IPOINT_BEFORE,(AFUNPTR)taintEngine.callFunction,
+                               IARG_ADDRINT, INS_Address(ins),
+                               IARG_PTR, new string(INS_Disassemble(ins)),
+                               IARG_BRANCH_TARGET_ADDR,
+                               IARG_END);
+                //}
+            }
+            if (INS_Disassemble(ins).rfind("ret") == 0 && !isLibraryFunction(INS_Address(ins))) {
+                INS_InsertCall(
+                               ins, IPOINT_BEFORE,(AFUNPTR)taintEngine.retFunction,
+                               IARG_ADDRINT, INS_Address(ins),
+                               IARG_PTR, new string(INS_Disassemble(ins)),
+                               IARG_END);
+            }
             if (INS_MemoryOperandIsRead(ins, 0) && INS_OperandIsReg(ins, 0)){
-                  INS_InsertCall(
+                INS_InsertCall(
                                ins, IPOINT_BEFORE,(AFUNPTR)taintEngine.readMem,
                                IARG_ADDRINT, INS_Address(ins),
                                IARG_PTR, new string(INS_Disassemble(ins)),

--- a/TaintTracker/TaintTracker.h
+++ b/TaintTracker/TaintTracker.h
@@ -30,4 +30,3 @@ private:
     std::list<struct range> bytesTainted;
 };
 
-extern TaintTracker taintEngine(256);

--- a/TaintTracker/TaintTracker.h
+++ b/TaintTracker/TaintTracker.h
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <iostream>
 #include <list>
+#include <stack>
 
 struct range {
     UINT64 start;
@@ -22,6 +23,11 @@ public:
     // Debug Functions
     static void readMem(UINT64, std::string, UINT64);
     static void writeMem(UINT64, std::string, UINT64);
+    static void callFunction(UINT64, std::string, UINT64);
+    static void retFunction(UINT64, std::string);
+
+    //TODO: make this private maybe?
+    std::stack <UINT64> callStack;
 private:
     // We will have the taint variables here
     // Maximum taint size
@@ -29,4 +35,3 @@ private:
     range taint;
     std::list<struct range> bytesTainted;
 };
-

--- a/TaintTracker/make_test.sh
+++ b/TaintTracker/make_test.sh
@@ -1,0 +1,4 @@
+PIN_ROOT=../pin make clean; PIN_ROOT=../pin make
+cd testprograms
+./test.sh
+cd ..

--- a/TaintTracker/testprograms/test.sh
+++ b/TaintTracker/testprograms/test.sh
@@ -1,0 +1,1 @@
+../../pin/pin -t ../obj-intel64/TaintTracker.so -- ./a.out

--- a/TaintTracker/testprograms/test1.c
+++ b/TaintTracker/testprograms/test1.c
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <unistd.h>
+
+void foo(char *buf)
+{
+  char a;
+
+  a = buf[0];
+  a = buf[4];
+  a = buf[8];
+  a = buf[10];
+  buf[5]  = 't';
+  buf[10] = 'e';
+  buf[20] = 's';
+  buf[30] = 't';
+}
+
+int main(int ac, char **av)
+{
+  int fd;
+  char *buf;
+
+  if (!(buf = malloc(256)))
+    return -1;
+
+  fd = open("./file.txt", O_RDONLY);
+  read(fd, buf, 256), close(fd);
+  foo(buf);
+}


### PR DESCRIPTION
added a stack "callStack" that keeps track of the functions. Currently showstack() does not print function names even if they are available and simply outputs in the "sub_<addr>" convention.